### PR TITLE
Using Haskell to generate infinite amounts of test data

### DIFF
--- a/Haskell/PhoneNumber.hs
+++ b/Haskell/PhoneNumber.hs
@@ -2,9 +2,17 @@ module PhoneNumber where
 
 import Test.QuickCheck
 
+maxLength :: Int
+maxLength = 15
+
 data Digit = Number Int
            | Space
            | Dash deriving (Show,Eq)	   
+
+instance Arbitrary Digit where
+  arbitrary = elements (Space : Dash : digits) where
+    digits = map Number [0..9]
+    
 
 data TelephoneNumber = TelephoneNumber [Digit] deriving (Show,Eq)
 

--- a/Haskell/PhoneNumber.hs
+++ b/Haskell/PhoneNumber.hs
@@ -1,5 +1,7 @@
 module PhoneNumber where
 
+import Test.QuickCheck
+
 data Digit = Number Int
            | Space
            | Dash deriving (Show,Eq)	   

--- a/Haskell/PhoneNumber.hs
+++ b/Haskell/PhoneNumber.hs
@@ -1,3 +1,5 @@
+-- Not intended to be good Haskell, just demonstrating something I find intesting, using QuickCheck to generate
+-- test data
 module PhoneNumber where
 
 import Test.QuickCheck
@@ -53,9 +55,12 @@ isNumber (Number _) = True
 isNumber _          = False
 
 -- Now, with this naive definition we can create test data that satisfies the definitions
+
+-- Create a list of addressbooks that are not consistent
 inconsistent :: IO [AddressBook]
 inconsistent = sample' (suchThat arbitrary (not . isConsistent))
 
+-- Create a list of consistent address books
 consistent :: IO [AddressBook]
 consistent = sample' (suchThat arbitrary isConsistent)
 

--- a/Haskell/PhoneNumber.hs
+++ b/Haskell/PhoneNumber.hs
@@ -28,8 +28,7 @@ isConsistent (AddressBook numbers) = not (any id (map (isPrefixOf numbers) numbe
 instance Arbitrary AddressBook where
   arbitrary = do
     nums <- listOf1 arbitrary
-    return (AdddressBook numbers)
-    
+    return (AddressBook nums)   
 
 isPrefixOf :: [TelephoneNumber] -> TelephoneNumber -> Bool
 isPrefixOf nums num = any (startsWith num)  nums

--- a/Haskell/PhoneNumber.hs
+++ b/Haskell/PhoneNumber.hs
@@ -12,11 +12,18 @@ data Digit = Number Int
 instance Arbitrary Digit where
   arbitrary = elements (Space : Dash : digits) where
     digits = map Number [0..9]
-    
 
 data TelephoneNumber = TelephoneNumber [Digit] deriving (Show,Eq)
+
+instance Arbitrary TelephoneNumber where  
+  arbitrary = do
+    nums <- listOf1 arbitrary
+    return (TelephoneNumber nums)
 
 data AddressBook = AddressBook [TelephoneNumber]
 
 isConsistent :: AddressBook -> Bool
-isConsistent (AddressBook numbers) = undefined 
+isConsistent (AddressBook numbers) = not (any id (map (isPrefixOf numbers) numbers))
+
+isPrefixOf :: [TelephoneNumber] -> TelephoneNumber -> Bool
+isPrefixOf = undefined

--- a/Haskell/PhoneNumber.hs
+++ b/Haskell/PhoneNumber.hs
@@ -8,18 +8,27 @@ maxLength = 15
 
 data Digit = Number Int
            | Space
-           | Dash deriving (Show,Eq)	   
+           | Dash deriving (Eq)	  
+
+instance Show Digit where 
+  show (Number x) = show x
+  show (Space   ) = " "
+  show (Dash    ) = "-"
 
 instance Arbitrary Digit where
   arbitrary = elements (Space : Dash : digits) where
     digits = map Number [0..9]
 
-data TelephoneNumber = TelephoneNumber [Digit] deriving (Show,Eq)
+data TelephoneNumber = TelephoneNumber [Digit] deriving (Eq)
+
+instance Show TelephoneNumber where
+  show (TelephoneNumber ds) = concatMap show ds
 
 instance Arbitrary TelephoneNumber where  
   arbitrary = do
+    num <- elements (map Number [0..9]) -- Must begin with number
     nums <- listOf1 arbitrary
-    return (TelephoneNumber nums)
+    return (TelephoneNumber (num:nums))
 
 data AddressBook = AddressBook [TelephoneNumber] deriving Show
 
@@ -36,4 +45,9 @@ isPrefixOf nums num = any (startsWith num)  nums
 
 -- Deliberately hyper naive!
 startsWith :: TelephoneNumber -> TelephoneNumber -> Bool
-startsWith (TelephoneNumber a) (TelephoneNumber b) = all id (zipWith (==) a b)
+startsWith (TelephoneNumber a) (TelephoneNumber b) = all id (zipWith (==) (filter isNumber a) (filter isNumber b))
+
+isNumber :: Digit -> Bool
+isNumber (Number _) = True
+isNumber _          = False
+

--- a/Haskell/PhoneNumber.hs
+++ b/Haskell/PhoneNumber.hs
@@ -19,16 +19,17 @@ instance Arbitrary Digit where
   arbitrary = elements (Space : Dash : digits) where
     digits = map Number [0..9]
 
-data TelephoneNumber = TelephoneNumber [Digit] deriving (Eq)
+data TelephoneNumber = TelephoneNumber String [Digit] deriving (Eq)
 
 instance Show TelephoneNumber where
-  show (TelephoneNumber ds) = concatMap show ds
+  show (TelephoneNumber name ds) = name ++ " : " ++ concatMap show ds
 
 instance Arbitrary TelephoneNumber where  
   arbitrary = do
     num <- elements (map Number [0..9]) -- Must begin with number
     nums <- listOf1 arbitrary
-    return (TelephoneNumber (num:nums))
+    name <- elements ["John", "Fred", "George"]
+    return (TelephoneNumber name (num:nums))
 
 data AddressBook = AddressBook [TelephoneNumber] deriving Show
 
@@ -45,9 +46,17 @@ isPrefixOf nums num = any (startsWith num)  nums
 
 -- Deliberately hyper naive!
 startsWith :: TelephoneNumber -> TelephoneNumber -> Bool
-startsWith (TelephoneNumber a) (TelephoneNumber b) = all id (zipWith (==) (filter isNumber a) (filter isNumber b))
+startsWith (TelephoneNumber _ a) (TelephoneNumber _ b) = all id (zipWith (==) (filter isNumber a) (filter isNumber b))
 
 isNumber :: Digit -> Bool
 isNumber (Number _) = True
 isNumber _          = False
+
+-- Now, with this naive definition we can create test data
+
+inconsistent :: IO [AddressBook]
+inconsistent = sample' (suchThat arbitrary (not . isConsistent))
+
+consistent :: IO [AddressBook]
+consistent = sample' (suchThat arbitrary isConsistent)
 

--- a/Haskell/PhoneNumber.hs
+++ b/Haskell/PhoneNumber.hs
@@ -52,8 +52,7 @@ isNumber :: Digit -> Bool
 isNumber (Number _) = True
 isNumber _          = False
 
--- Now, with this naive definition we can create test data
-
+-- Now, with this naive definition we can create test data that satisfies the definitions
 inconsistent :: IO [AddressBook]
 inconsistent = sample' (suchThat arbitrary (not . isConsistent))
 

--- a/Haskell/PhoneNumber.hs
+++ b/Haskell/PhoneNumber.hs
@@ -1,0 +1,12 @@
+module PhoneNumber where
+
+data Digit = Number Int
+           | Space
+           | Dash deriving (Show,Eq)	   
+
+data TelephoneNumber = TelephoneNumber [Digit] deriving (Show,Eq)
+
+data AddressBook = AddressBook [TelephoneNumber]
+
+isConsistent :: AddressBook -> Bool
+isConsistent (AddressBook numbers) = undefined 

--- a/Haskell/PhoneNumber.hs
+++ b/Haskell/PhoneNumber.hs
@@ -1,6 +1,7 @@
 module PhoneNumber where
 
 import Test.QuickCheck
+import Data.List ((\\))
 
 maxLength :: Int
 maxLength = 15
@@ -20,10 +21,10 @@ instance Arbitrary TelephoneNumber where
     nums <- listOf1 arbitrary
     return (TelephoneNumber nums)
 
-data AddressBook = AddressBook [TelephoneNumber]
+data AddressBook = AddressBook [TelephoneNumber] deriving Show
 
 isConsistent :: AddressBook -> Bool
-isConsistent (AddressBook numbers) = not (any id (map (isPrefixOf numbers) numbers))
+isConsistent (AddressBook numbers) = not (any id (map (\n -> isPrefixOf (numbers \\ [n]) n) numbers))
 
 instance Arbitrary AddressBook where
   arbitrary = do
@@ -33,5 +34,6 @@ instance Arbitrary AddressBook where
 isPrefixOf :: [TelephoneNumber] -> TelephoneNumber -> Bool
 isPrefixOf nums num = any (startsWith num)  nums
 
+-- Deliberately hyper naive!
 startsWith :: TelephoneNumber -> TelephoneNumber -> Bool
 startsWith (TelephoneNumber a) (TelephoneNumber b) = all id (zipWith (==) a b)

--- a/Haskell/PhoneNumber.hs
+++ b/Haskell/PhoneNumber.hs
@@ -25,5 +25,14 @@ data AddressBook = AddressBook [TelephoneNumber]
 isConsistent :: AddressBook -> Bool
 isConsistent (AddressBook numbers) = not (any id (map (isPrefixOf numbers) numbers))
 
+instance Arbitrary AddressBook where
+  arbitrary = do
+    nums <- listOf1 arbitrary
+    return (AdddressBook numbers)
+    
+
 isPrefixOf :: [TelephoneNumber] -> TelephoneNumber -> Bool
-isPrefixOf = undefined
+isPrefixOf nums num = any (startsWith num)  nums
+
+startsWith :: TelephoneNumber -> TelephoneNumber -> Bool
+startsWith (TelephoneNumber a) (TelephoneNumber b) = all id (zipWith (==) a b)


### PR DESCRIPTION
One of the things I'm really interested in is QuickCheck (http://en.wikipedia.org/wiki/QuickCheck).  This is the idea that you express tests as assertions of invariants (rather than spot checking some data).

One of the really neat things you can do with this is model-based testing.  In this example I've specified what a consistent phone book looks like.  Instead of needing to manually create test data (or scrape from sources), I can ask Haskell to generate some test data for which a particular invariant holds.

I really like this approach for tests, as it allows me to write a really naive implementation and get the acceptance test for that sorted, before drilling into a more proper implementation (I imagine for this Phone Numbers exercise, I'd need to use prefix trees or something else cleverer than a brute force search).

I just thought I'd throw this pull request in as it's something I find interesting!
